### PR TITLE
Pclouds 2683 app service linux write bash script to determine linux distribution

### DIFF
--- a/azure/linux-app-service/oneagent_installer.sh
+++ b/azure/linux-app-service/oneagent_installer.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+readonly ID_PREFIX='^ID='
+readonly LIB_MUSL="musl"
+readonly LIB_GCLIB="libc"
+readonly LIB_DEFAULT="default"
+readonly OS_RELEASE_FILE="/etc/os-release"
+readonly ALPINE_RELEASE_FILE="/etc/alpine-release"
+readonly DISTRIBUTION_WITH_MUSL="alpine"
+
+readonly INSTALLER_LOCATION="/tmp/installer.sh"
+readonly INSTALLER_URL_SUFFIX="api/v1/deployment/installer/agent/unix/paas-sh/latest"
+
+# Try using ldd command
+check_ldd() {
+
+    ldd_result=$(ldd --version)
+    readonly ldd_result
+
+    if echo "$ldd_result" | grep -qi "$LIB_MUSL"; then
+        lib="$LIB_$LIB_MUSL"
+    elif echo "$ldd_result" | grep -qi "$LIB_GCLIB"; then
+        lib="$LIB_DEFAULT"
+    fi
+}
+
+
+check_release_file() {
+
+    os_id=$(grep "$ID_PREFIX" "$OS_RELEASE_FILE" | cut -d= -f2 > /dev/null 2>&1)
+    # -d specifies delimeter "=" and -f2 caputres second group after splitting
+
+    if test "$os_id" = "$DISTRIBUTION_WITH_MUSL"; then
+        lib="$LIB_MUSL"
+    fi
+
+}
+
+check_alpine_release_file() {
+
+    if [ -f "$ALPINE_RELEASE_FILE" ]; then
+        lib="$LIB_MUSL"
+    fi
+
+}
+
+
+run() {
+
+    wget -O "$INSTALLER_LOCATION" -q "$DT_ENDPOINT/$INSTALLER_URL_SUFFIX?Api-Token=$DT_API_TOKEN&flavor=$DT_FLAVOR&include=$DT_INCLUDE"
+    sh "$INSTALLER_LOCATION"
+
+    # Inject variable into the proccess and run the actual application proccess
+    LD_PRELOAD="/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so" $START_APP_CMD
+
+}
+
+
+main() {
+
+    lib=""
+
+    # First check using ldd utility
+    check_ldd
+
+    # If empty check /etc/os-release
+    if test -z "$lib"; then
+        check_release_file
+    fi
+
+    # If still empty check if Alpine release file exists
+    if test -z "$lib"; then
+        check_alpine_release_file
+    fi
+
+    # If lib is empty at the end, set it to "default"
+    if test -z "$lib"; then
+        lib="$LIB_DEFAULT"
+    fi
+
+    # Set dt_flavor based on detected libc
+    DT_FLAVOR="$lib"
+
+    run
+
+}
+
+main

--- a/azure/linux-app-service/oneagent_installer.sh
+++ b/azure/linux-app-service/oneagent_installer.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-readonly ID_PREFIX='^ID='
 readonly LIB_MUSL="musl"
 readonly LIB_GCLIB="libc"
 readonly LIB_DEFAULT="default"
-readonly OS_RELEASE_FILE="/etc/os-release"
 readonly ALPINE_RELEASE_FILE="/etc/alpine-release"
-readonly DISTRIBUTION_WITH_MUSL="alpine"
 
 readonly INSTALLER_LOCATION="/tmp/installer.sh"
 readonly INSTALLER_URL_SUFFIX="api/v1/deployment/installer/agent/unix/paas-sh/latest"
@@ -22,18 +19,6 @@ check_ldd() {
     elif echo "$ldd_result" | grep -qi "$LIB_GCLIB"; then
         lib="$LIB_DEFAULT"
     fi
-}
-
-
-check_release_file() {
-
-    os_id=$(grep "$ID_PREFIX" "$OS_RELEASE_FILE" | cut -d= -f2 > /dev/null 2>&1)
-    # -d specifies delimeter "=" and -f2 caputres second group after splitting
-
-    if test "$os_id" = "$DISTRIBUTION_WITH_MUSL"; then
-        lib="$LIB_MUSL"
-    fi
-
 }
 
 check_alpine_release_file() {
@@ -62,11 +47,6 @@ main() {
 
     # First check using ldd utility
     check_ldd
-
-    # If empty check /etc/os-release
-    if test -z "$lib"; then
-        check_release_file
-    fi
 
     # If still empty check if Alpine release file exists
     if test -z "$lib"; then


### PR DESCRIPTION
Wrote a bash script that detects which standard C library (musl/glibc) is used in the Azure Linux App Service container and then sets the DT_FLAVOR value accordingly.  

It works in the following way:
1. Parse``` ldd --version output``` -> ldd is a utility that prints the shared libraries and it should contain information about libc
2. If we didn't get the answer from ldd we check the ```/etc/os-release``` file and check if it's an alpine based distro as the musl library is usually present in those.
3. If we still don't know we check if  ```etc/alpine-release``` is present for the same reason as before.
