### PR TITLE
add CF template for  AWS ECR event forwarder OpenPipeline security event ingest

### DIFF
--- a/aws/aws-ecr-event-forwarder/README.md
+++ b/aws/aws-ecr-event-forwarder/README.md
@@ -1,0 +1,55 @@
+# AWS Event Forwarder Lambda
+
+This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings for [basic scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html) to the Dynatrace OpenPipeline security event ingest endpoint.
+
+More details can be found in the official documentation:
+
+- [Security events ingest](https://dt-url.net/1d63p0v)
+- [Ingest AWS ECR vulnerability findings](https://dt-url.net/tz03pa8)
+
+Follow these steps to create the AWS ECR Event Forwarder with Infrastructure as Code (IaC):
+
+### 0. Prerequisites
+
+- Dynatrace version 1.296+
+- Make sure to install and configure the [latest AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- In a terminal, enter `aws configure` and set `us-east-1` as the default region for setting up all resources.
+
+### 1. Set up secret with OpenPipeline Api-Token
+
+Replace the Api-Token in the following command with a valid [access token](https://docs.dynatrace.com/docs/manage/access-control/access-tokens) that has the `open-pipeline.ingest.events.security` token scope:
+
+```bash
+aws secretsmanager create-secret \
+--name dynatrace-aws-ecr-event-forwarder-open-pipeline-ingest-api-token \
+--description "Dynatrace Token, which allows to send data to the Open Pipeline endpoint." \
+--secret-string '{"DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN": "Api-Token"}'
+```
+
+### 2. Create the resources in AWS with the CloudFormation template
+
+The following command executes the CloudFormation template and creates the necessary resources. Replace the `AwsSecretArn` variable in the following command with the actual ARN of the secret that was created in the previous step:
+
+```bash
+aws cloudformation deploy  \
+--template-file ./dynatrace_aws_event_forwarder_template.yaml \
+--stack-name dynatrace-aws-ecr-event-forwarder \
+--parameter-overrides \
+"AwsSecretArn"="arn:aws:secretsmanager:us-east-1:12345678:secret:dynatrace-aws-ecr-event-forwarder-open-pipeline-ingest-api-token-testxyz" \
+"DynatraceDomain"="{your-environment-id}.live.dynatrace.com" \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+#### Additional parameters that can be customized:
+
+- `AwsSecretKeyName`: Name of the secret key, defaults to `DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN`
+
+- `DynatraceOpenPipelineEndpointPath`: Path of the OpenPipeline security endpoint, defaults to `/platform/ingest/v1/events.security?type=container_finding&provider_product=aws_ecr`
+
+### Tip: (Optional) Delete stack
+
+If they're not needed anymore, you can delete the resources created from AWS with the following command:
+
+```bash
+aws cloudformation delete-stack --stack-name dynatrace-aws-ecr-event-forwarder
+```

--- a/aws/aws-ecr-event-forwarder/dynatrace_aws_event_forwarder_template.yaml
+++ b/aws/aws-ecr-event-forwarder/dynatrace_aws_event_forwarder_template.yaml
@@ -1,0 +1,224 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Template for Dynatrace AWS ECR Image Scan Event Forwarder.
+
+Metadata:
+  License:
+    Description: |
+      Copyright 2024 Dynatrace LLC
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+Parameters:
+  AwsSecretArn:
+    Description: Arn of the created secret upfront.
+    Type: String
+
+  AwsSecretKeyName:
+    Description: Name of the secret key.
+    Default: "DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN"
+    Type: String
+
+  DynatraceDomain:
+    Description: Domain of your Dynatrace instance e.g. ab12345.live.dynatrace.com
+    Type: String
+
+  DynatraceOpenPipelineEndpointPath:
+    Description: Path of the OpenPipeline security endpoint.
+    Default: "/platform/ingest/v1/events.security?type=container_finding&provider_product=aws_ecr"
+    Type: String
+
+Resources:
+  DynatraceECREventForwarderLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: dynatrace-aws-ecr-event-forwarder-lambda-role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSLambdaExecute
+      Path: /
+      Policies:
+        - PolicyName: "read-ecr-image-scans"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ecr:DescribeImageScanFindings"
+                Resource: !Sub "arn:aws:ecr:*:${AWS::AccountId}:repository/*"
+                Sid: "VisualEditor0"
+        - PolicyName: "read-dynatrace-secret-token"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                Resource: !Ref AwsSecretArn
+                Sid: "VisualEditor0"
+
+  DynatraceECREventForwarderLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dynatrace-aws-ecr-event-forwarder-lambda
+      Description: Dynatrace AWS ECR Image Scan event forwarder Lambda function.
+      TracingConfig:
+        Mode: "PassThrough"
+      Runtime: python3.12
+      Code:
+        ZipFile: |
+          import http.client
+          import json
+          import boto3
+          import copy
+          import os
+
+          AWS_SECRET_ARN = os.environ["AWS_SECRET_ARN"]
+          AWS_SECRET_KEY_NAME = os.environ["AWS_SECRET_KEY_NAME"]
+
+          DYNATRACE_DOMAIN = os.environ["DYNATRACE_DOMAIN"]
+          DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH = os.environ["DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH"]
+
+          def lambda_handler(event, context):
+              try:
+                  # get token from secret manager
+                  token = get_token_secret()
+
+                  # get event information, from the EventBridge
+                  image_digest = event["detail"]["image-digest"]
+                  repo_name = event["detail"]["repository-name"]
+                  repo_region = event["region"]
+                  image_tags = event["detail"]["image-tags"]
+
+                  scan_results = get_scan_findings(image_digest, repo_name, "")
+                  process_scan_results(scan_results, repo_region, image_tags, token)
+                  next_token = scan_results.get("nextToken")
+
+                  while next_token:
+                      scan_results = get_scan_findings(image_digest, repo_name, next_token)
+                      process_scan_results(scan_results, repo_region, image_tags, token)
+                      next_token = scan_results.get("nextToken")
+
+                  return {
+                      "statusCode": 200,
+                      "body": "Executed OpenPipeline security event export"
+                  }
+              except Exception as e:
+                  print(f'Error executing OpenPipeline security event export: {str(e)}')
+
+                  return {
+                      'statusCode': 500,
+                      'body': 'Error executing OpenPipeline security event export'
+                  }
+
+          def process_scan_results(scan_results, repo_region, image_tags, token):
+              process_entries = []
+              for finding in scan_results.get("imageScanFindings").get("findings"):
+                  processed_entry = copy.deepcopy(scan_results)
+                  processed_entry["imageScanFindings"]["findings"] = [finding]
+                  processed_entry["region"] = repo_region
+                  processed_entry["image-tags"] = image_tags
+
+                  process_entries.append(processed_entry)
+
+              json_string = json.dumps(process_entries, default=str)
+              send_data_to_pipeline(json_string, token)
+
+          def get_scan_findings(image_digest, repository_name, next_token):
+              ecr_client = boto3.client("ecr")
+              response = ""
+
+              if next_token != "":
+                  response = ecr_client.describe_image_scan_findings(
+                      repositoryName=repository_name,
+                      imageId={"imageDigest": image_digest},
+                      nextToken=next_token
+                  )
+              else:
+                  response = ecr_client.describe_image_scan_findings(
+                      repositoryName=repository_name,
+                      imageId={"imageDigest": image_digest}
+                  )
+
+              return response
+
+          def send_data_to_pipeline(data, token):
+              conn = http.client.HTTPSConnection(DYNATRACE_DOMAIN)
+
+              headers = {
+                  "Authorization": "Api-Token " + token,
+                  "Content-Type": "application/json",
+              }
+              
+              conn.request("POST", DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH, body=data, headers=headers)
+              response = conn.getresponse()
+
+              if response.status > 299:
+                print(f"Error sending sending data to OpenPipeline, response status is: {str(response.status)}")
+
+          def get_token_secret():
+              # Create a Secrets Manager client
+              session = boto3.session.Session()
+              client = session.client(
+                  service_name="secretsmanager"
+              )
+
+              get_secret_value_response = client.get_secret_value(
+                  SecretId=AWS_SECRET_ARN
+              )
+
+              # json string containing the secret
+              secret_json = get_secret_value_response["SecretString"]
+              secret_dict = json.loads(secret_json)
+
+              return secret_dict[AWS_SECRET_KEY_NAME]
+      Handler: "index.lambda_handler"
+      MemorySize: 128
+      Timeout: 600
+      Role: !GetAtt DynatraceECREventForwarderLambdaRole.Arn
+      Environment:
+        Variables:
+          AWS_SECRET_ARN: !Ref AwsSecretArn
+          AWS_SECRET_KEY_NAME: !Ref AwsSecretKeyName
+          DYNATRACE_DOMAIN: !Ref DynatraceDomain
+          DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH: !Ref DynatraceOpenPipelineEndpointPath
+
+  DynatraceECREventForwarderEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Forwards the event for a completed ECR Image Scan automatically to the lambda function, which sends it to OpenPipeline"
+      EventPattern:
+        detail-type:
+          - "ECR Image Scan"
+        source:
+          - "aws.ecr"
+      EventBusName: "default"
+      Targets:
+        - Arn: !GetAtt DynatraceECREventForwarderLambdaFunction.Arn
+          Id: "TargetFunction"
+
+  DynatraceECREventForwarderLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt DynatraceECREventForwarderLambdaFunction.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DynatraceECREventForwarderEventRule.Arn


### PR DESCRIPTION
This PR adds a CloudFormation template and instructions on how to set up the AWS ECR event forwarder setup for OpenPipeline security event ingest.