### PR TITLE
Change the URL of the wrapper installer to point to GitHub instead o fazure blob

### DIFF
--- a/azure/linux-app-service/linux-app-service.json
+++ b/azure/linux-app-service/linux-app-service.json
@@ -85,7 +85,7 @@
 
     "installerWrapper": {
       "installationPath": "/tmp/installer-wrapper.sh",
-      "URL": "https://mjarzemb.blob.core.windows.net/mjarzemb-public/oneagent-installer.sh",
+      "URL": "https://raw.githubusercontent.com/dynatrace-oss/cloud-snippets/main/azure/linux-app-service/oneagent-installer.sh",
       "runCommand": "sh /tmp/installer-wrapper.sh"
     },
 


### PR DESCRIPTION
I used the Azure blob to check if it works, and I wanted to change the URL to point to GitHub after the code was merged, to be sure what URL it would be, but I forgot to do it.