### PR TITLE
Remove AWS provider settings from Terraform templates. 

### DIFF
--- a/aws/role-based-access/terraform-templates/README.md
+++ b/aws/role-based-access/terraform-templates/README.md
@@ -26,7 +26,6 @@ The deployment with no ActiveGate can be done by using the [dynatrace_monitoring
 
 You need to specify the following arguments:
 
-* `region`: The region where policy will be created
 * `external_id`: External ID, copied from Settings > Cloud and virtualization > AWS in Dynatrace
 * `role_name`: IAM role name that Dynatrace should use to get monitoring data. This must be the same name as the monitoring_role_name parameter used in the template for the account hosting the ActiveGate.
 * `policy_name`: IAM policy name attached to the role
@@ -36,7 +35,6 @@ You need to specify the following arguments:
 
 You can prepare a `.tfvars` with your arguments. For instance:
 ```hcl
-region               = "east-us-1"
 monitored_account_id = "999999999999"
 assume_policy_name   = "sample_dynatrace_assume_policy"
 monitoring_role_name = "sample_dynatrace_monitoring_role"
@@ -57,7 +55,6 @@ To configure a deployment with an existing ActiveGate, you should use two Terraf
 #### Create a role for ActiveGate on the account that hosts ActiveGate
 
 You can use [activegate_monitoring_role](./activegate_monitoring_role/) specifying the following arguments:
-* `region`: The region where you want to create the policy
 * `active_gate_role_name`: IAM role name for the account hosting the ActiveGate for monitoring. This role name must be the same as the ActiveGate_role_name parameter used in the template for the monitored account.
 * `assume_policy_name`:  IAM policy name attached to the role for the account hosting the ActiveGate
 * `monitoring_role_name`: IAM role name that Dynatrace should use to get monitoring data. This role must be the same name as the RoleName parameter used in the template for the monitored account.
@@ -66,7 +63,6 @@ You can use [activegate_monitoring_role](./activegate_monitoring_role/) specifyi
 Now you can prepare a `.tfvars` file with the following arguments:
 
 ```hcl
-region                = "east-us-1"
 active_gate_role_name = "dynatrace_ag_role_name"
 assume_policy_name    = "dynatrace_assume_policy"
 monitoring_role_name  = "dynatrace_monitoring_role"
@@ -83,7 +79,6 @@ terraform apply -var-file="my_variables.tfvars"
 
 To create the monitoring role, you can use [dynatrace_monitoring_role](./dynatrace_monitoring_role/) module. You need to specify the following arguments:
 
-* `region`: The region where policy will be created
 * `external_id`: External ID, copied from Settings > Cloud and virtualization > AWS in Dynatrace
 * `role_name`: IAM role name that Dynatrace should use to get monitoring data. This must be the same name as the monitoring_role_name parameter used in the template for the account hosting the ActiveGate.
 * `policy_name`: IAM policy name attached to the role
@@ -92,7 +87,6 @@ To create the monitoring role, you can use [dynatrace_monitoring_role](./dynatra
 
 Now you can prepare a `.tfvars` file with the following arguments:
 ```hcl
-region                 = "east-us-1"
 monitored_account_id   = "999999999999"
 assume_policy_name     = "sample_dynatrace_assume_policy"
 monitoring_role_name   = "sample_dynatrace_monitoring_role"
@@ -104,4 +98,23 @@ Now, you can execute the following Terraform commands to apply the configuration
 ```bash
 terraform init
 terraform apply -var-file="my_variables.tfvars"
+```
+
+### Set the region
+
+By default, AWS will create the resources in your default region. If you want to specify the region you can configure the AWS provider. For that include the following in your Terraform template:
+```hcl
+terraform {
+  required_version = ">=1.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
 ```

--- a/aws/role-based-access/terraform-templates/activegate_monitoring_role/main.tf
+++ b/aws/role-based-access/terraform-templates/activegate_monitoring_role/main.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_version = ">=1.7"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = var.region
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "active_gate_role_assume_role_policy_document" {

--- a/aws/role-based-access/terraform-templates/activegate_monitoring_role/variables.tf
+++ b/aws/role-based-access/terraform-templates/activegate_monitoring_role/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  description = "The region where policy will be created"
-  type        = string
-  default     = "us-east-1"
-}
-
 variable "active_gate_role_name" {
   description = "IAM role name for the account hosting the ActiveGate for monitoring. This must be the same name as the ActiveGate_role_name parameter used in the template for the monitored account."
   type        = string

--- a/aws/role-based-access/terraform-templates/dynatrace_monitoring_role/main.tf
+++ b/aws/role-based-access/terraform-templates/dynatrace_monitoring_role/main.tf
@@ -1,20 +1,4 @@
-terraform {
-  required_version = ">=1.7"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = var.region
-}
-
 data "aws_caller_identity" "current" {}
-
-
 
 locals {
   principals_identifiers = var.active_gate_account_id == null || var.active_gate_role_name == null ? [

--- a/aws/role-based-access/terraform-templates/dynatrace_monitoring_role/variables.tf
+++ b/aws/role-based-access/terraform-templates/dynatrace_monitoring_role/variables.tf
@@ -1,9 +1,3 @@
-variable "region" {
-  description = "The region where policy will be created"
-  type        = string
-  default     = "us-east-1"
-}
-
 variable "external_id" {
   description = "External ID, copied from Settings > Cloud and virtualization > AWS in Dynatrace"
   type        = string


### PR DESCRIPTION
Remove AWS provider settings from Terraform templates. The consumers of these snippets can include the settings in their modules.

See Issue #17 