### PR TITLE
remove trailing slash from the DT_ENDPOINT env variable

### DIFF
--- a/azure/linux-app-service/oneagent-installer.sh
+++ b/azure/linux-app-service/oneagent-installer.sh
@@ -32,6 +32,10 @@ check_alpine_release_file() {
 
 run() {
 
+    # shellcheck disable=SC2116
+    # this trims one trailing slash
+    DT_ENDPOINT=$(echo "${DT_ENDPOINT%/}")
+
     wget -O "$INSTALLER_DOWNLOAD_PATH" -q "$DT_ENDPOINT/$INSTALLER_URL_SUFFIX?Api-Token=$DT_API_TOKEN&flavor=$DT_FLAVOR&include=$DT_INCLUDE"
     sh "$INSTALLER_DOWNLOAD_PATH"
 


### PR DESCRIPTION
I tested it on both glibc and musl containers and it works on both.