### PR TITLE
Add scan event support for AWS ECR Event forwarder basic and enhanced scanning

### DIFF
--- a/aws/aws-ecr-event-forwarder-enhanced/README.md
+++ b/aws/aws-ecr-event-forwarder-enhanced/README.md
@@ -1,6 +1,6 @@
 # AWS Event Forwarder Lambda - Enhanced scanning
 
-This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings for [enhanced scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html) to the Dynatrace OpenPipeline security event ingest endpoint.
+This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings and scan events for [enhanced scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html) to the Dynatrace OpenPipeline security event ingest endpoint.
 
 More details can be found in the official documentation:
 
@@ -11,7 +11,13 @@ Follow these steps to create the AWS ECR Event Forwarder for enhanced scanning w
 
 ### 0. Prerequisites
 
-- Dynatrace version 1.298+
+- Dynatrace version
+
+  | Feature                | Version |
+  | ---------------------- | ------- |
+  | vulnerability findings | 1.298+  |
+  | scan events            | 1.301+  |
+
 - Make sure to install and configure the [latest AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - In a terminal, enter `aws configure` and set `us-east-1` (or your preferred region) as the default region for setting up all resources.
 

--- a/aws/aws-ecr-event-forwarder-enhanced/dynatrace_aws_event_forwarder_enhanced_template.yaml
+++ b/aws/aws-ecr-event-forwarder-enhanced/dynatrace_aws_event_forwarder_enhanced_template.yaml
@@ -99,8 +99,14 @@ Resources:
               try:
                   # get token from secret manager
                   token = get_token_secret()
+                  detail_type = event.get("detail-type")
 
-                  process_finding(event, token)
+                  if detail_type == "Inspector2 Finding":
+                      process_finding(event, token)
+                  elif detail_type == "Inspector2 Scan":
+                      process_scan(event, token)
+                  else:
+                      raise Exception(f'Unsupported detail-type: "{str(detail_type)}"')
 
                   return {
                       "statusCode": 200,
@@ -142,6 +148,10 @@ Resources:
               json_string = json.dumps(process_entries, default=str)
               send_data_to_pipeline(json_string, token)
 
+          def process_scan(event, token):
+              json_string = json.dumps(event, default=str)
+              send_data_to_pipeline(json_string, token)
+
           def send_data_to_pipeline(data, token):
               conn = http.client.HTTPSConnection(DYNATRACE_DOMAIN)
 
@@ -166,7 +176,7 @@ Resources:
           DYNATRACE_DOMAIN: !Ref DynatraceDomain
           DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH: !Ref DynatraceOpenPipelineEndpointPath
 
-  DynatraceEventForwarderEnhancedEventRule:
+  DynatraceEventForwarderEnhancedFindingEventRule:
     Type: AWS::Events::Rule
     Properties:
       Description: "Forwards the Inspector2 finding events (Enhanced scanning) to the Dynatrace enhanced lambda function, which sends it to OpenPipeline"
@@ -185,10 +195,37 @@ Resources:
         - Arn: !GetAtt DynatraceEventForwarderEnhancedLambdaFunction.Arn
           Id: "TargetFunction"
 
-  DynatraceEventForwarderLambdaEnhancedPermission:
+  DynatraceEventForwarderEnhancedScanEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Forwards the Inspector2 scan events (Enhanced scanning) to the Dynatrace enhanced lambda function, which sends it to OpenPipeline"
+      EventPattern:
+        detail-type:
+          - "Inspector2 Scan"
+        detail:
+          scan-status:
+            - "INITIAL_SCAN_COMPLETE"
+          image-digest:
+            - exists: true
+        source:
+          - "aws.inspector2"
+      EventBusName: "default"
+      Targets:
+        - Arn: !GetAtt DynatraceEventForwarderEnhancedLambdaFunction.Arn
+          Id: "TargetFunction"
+
+  DynatraceEventForwarderLambdaEnhancedFindingPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt DynatraceEventForwarderEnhancedLambdaFunction.Arn
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt DynatraceEventForwarderEnhancedEventRule.Arn
+      SourceArn: !GetAtt DynatraceEventForwarderEnhancedFindingEventRule.Arn
+
+  DynatraceEventForwarderLambdaEnhancedScanPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt DynatraceEventForwarderEnhancedLambdaFunction.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DynatraceEventForwarderEnhancedScanEventRule.Arn

--- a/aws/aws-ecr-event-forwarder/README.md
+++ b/aws/aws-ecr-event-forwarder/README.md
@@ -1,6 +1,6 @@
 # AWS Event Forwarder Lambda - Basic scanning
 
-This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings for [basic scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html) to the Dynatrace OpenPipeline security event ingest endpoint.
+This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings and scan events for [basic scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html) to the Dynatrace OpenPipeline security event ingest endpoint.
 
 More details can be found in the official documentation:
 
@@ -11,7 +11,13 @@ Follow these steps to create the AWS ECR Event Forwarder with Infrastructure as 
 
 ### 0. Prerequisites
 
-- Dynatrace version 1.296+
+- Dynatrace version
+
+  | Feature                | Version |
+  | ---------------------- | ------- |
+  | vulnerability findings | 1.296+  |
+  | scan events            | 1.301+  |
+
 - Make sure to install and configure the [latest AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - In a terminal, enter `aws configure` and set `us-east-1` (or your preferred region) as the default region for setting up all resources.
 

--- a/aws/aws-ecr-event-forwarder/dynatrace_aws_event_forwarder_template.yaml
+++ b/aws/aws-ecr-event-forwarder/dynatrace_aws_event_forwarder_template.yaml
@@ -104,6 +104,8 @@ Resources:
                   # get token from secret manager
                   token = get_token_secret()
 
+                  send_scan_complete_event_to_pipeline(event, token)
+
                   # get event information, from the EventBridge
                   image_digest = event["detail"]["image-digest"]
                   repo_name = event["detail"]["repository-name"]
@@ -162,7 +164,7 @@ Resources:
 
               return response
 
-          def send_data_to_pipeline(data, token):
+          def send_data_to_pipeline(data, token, path=DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH):
               conn = http.client.HTTPSConnection(DYNATRACE_DOMAIN)
 
               headers = {
@@ -170,7 +172,7 @@ Resources:
                   "Content-Type": "application/json",
               }
               
-              conn.request("POST", DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH, body=data, headers=headers)
+              conn.request("POST", path, body=data, headers=headers)
               response = conn.getresponse()
 
               if response.status > 299:
@@ -192,6 +194,12 @@ Resources:
               secret_dict = json.loads(secret_json)
 
               return secret_dict[AWS_SECRET_KEY_NAME]
+
+          def send_scan_complete_event_to_pipeline(event, token):
+              event_json = json.dumps(event)
+              pipeline_path_without_query = DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH.split("?")[0]
+
+              send_data_to_pipeline(event_json, token, pipeline_path_without_query)
       Handler: "index.lambda_handler"
       MemorySize: 128
       Timeout: 600


### PR DESCRIPTION
This PR adapts the AWS ECR Event forwarder CF templates with support for scan (complete) events.

Both CF templates for basic and enhanced scanning are adapted.

Additionally, the READMEs have been updated to reflect the changes and required Dynatrace versions.