### PR TITLE
Add AWS Security Hub event forwarder

### DIFF
--- a/aws/aws-security-hub-event-forwarder/README.md
+++ b/aws/aws-security-hub-event-forwarder/README.md
@@ -1,0 +1,68 @@
+# AWS Security Hub event forwarder
+
+This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up the necessary resources in AWS to forward AWS Security Hub to the Dynatrace OpenPipeline security event ingest endpoint.
+
+More details can be found in the official documentation:
+
+- [Security events ingest](https://dt-url.net/1d63p0v)
+- [Ingest AWS Security Hub findings](https://dt-url.net/bl23u9i)
+
+Follow the steps below to create the AWS Security Hub event forwarder with Infrastructure as Code (IaC):
+
+### 0. Prerequisites
+
+- Dynatrace version
+
+  | Feature                | Version |
+  | ---------------------- | ------- |
+  | vulnerability findings | 1.306+  |
+
+- Make sure to install and configure the [latest AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+- In a terminal, enter `aws configure` and set `us-central-1` (or your preferred region) as the default region.
+- Make sure that any previous deployments of the Dynatrace AWS Security Hub event forwarder template are deleted by running:
+
+  ```bash
+  aws cloudformation delete-stack --stack-name dynatrace-aws-security-hub-event-forwarder
+  ```
+
+### 1. Set up the secret with the OpenPipeline Api-Token
+
+Run the following command, making sure to replace the Api-Token with a valid [access token](https://docs.dynatrace.com/docs/manage/access-control/access-tokens) that has the `openpipeline.events_security` token scope.
+
+```bash
+aws secretsmanager create-secret \
+--name dynatrace-aws-security-hub-event-forwarder-open-pipeline-ingest-api-token \
+--description "Dynatrace Token, which allows to send data to the Open Pipeline endpoint." \
+--secret-string '{"DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN": "<Token>"}'
+```
+
+### 2. Create the resources in AWS with the CloudFormation template
+
+Run the following command to execute the CloudFormation template and create the necessary resources.
+Make sure to replace the `AwsSecretArn` variable in the following command with the actual ARN of the secret that was created in the previous step.
+
+```bash
+aws cloudformation deploy  \
+--template-file ./dynatrace_aws_security_hub_event_forwarder_template.yaml \
+--stack-name dynatrace-aws-security-hub-event-forwarder \
+--parameter-overrides \
+"AwsSecretArn"="arn:aws:secretsmanager:us-east-1:12345678:secret:dynatrace-aws-security-hub-event-forwarder-open-pipeline-ingest-api-token-testxyz" \
+"DynatraceDomain"="https://{your-environment-id}.live.dynatrace.com/platform/ingest/v1/events.security" \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+#### Additional parameters that can be customized
+
+- `AwsSecretKeyName`: Name of the secret key, defaults to `DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN`
+
+- `FindingTypes`: FindingTypes in the format of namespace/category/classifier, see [ASFF finding types](https://docs.aws.amazon.com/securityhub/latest/userguide/asff-required-attributes.html#Types) for details. Multiple resource types can be provided with a comma separated list. Defaults to `Software and Configuration Checks/Vulnerabilities/CVE`
+
+- `DynatraceOpenPipelineEndpointPath`: Path to the OpenPipeline security endpoint, defaults to `/platform/ingest/v1/events.security`
+
+### (Optional) Delete stack
+
+If they're not needed anymore, you can delete the resources created from AWS with the following command:
+
+```bash
+aws cloudformation delete-stack --stack-name dynatrace-aws-security-hub-event-forwarder
+```

--- a/aws/aws-security-hub-event-forwarder/dynatrace_aws_security_hub_event_forwarder_template.yaml
+++ b/aws/aws-security-hub-event-forwarder/dynatrace_aws_security_hub_event_forwarder_template.yaml
@@ -1,0 +1,201 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Template for Dynatrace AWS Security Hub Event Forwarder
+
+Metadata:
+  License:
+    Description: |
+      Copyright 2024 Dynatrace LLC
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+Parameters:
+  AwsSecretArn:
+    Description: Arn of the created secret upfront.
+    Type: String
+
+  AwsSecretKeyName:
+    Description: Name of the secret key.
+    Default: "DYNATRACE_OPENPIPELINE_INGEST_API_TOKEN"
+    Type: String
+
+  FindingTypes:
+    Description: FindingTypes in the format of namespace/category/classifier, according to AWS documentation. Multiple resource types can be provided with a comma separated list.
+    Default: "Software and Configuration Checks/Vulnerabilities/CVE"
+    Type: String
+
+  DynatraceDomain:
+    Description: Domain of your Dynatrace instance e.g. ab12345.live.dynatrace.com
+    AllowedPattern: "^[A-Za-z0-9]+\\.live\\.dynatrace\\.com"
+    ConstraintDescription: "Malformed input-Parameter DynatraceDomain must match pattern {your-environment-id}.live.dynatrace.com"
+    Type: String
+
+  DynatraceOpenPipelineEndpointPath:
+    Description: Path of the OpenPipeline security endpoint.
+    Default: "/platform/ingest/v1/events.security"
+    Type: String
+
+Resources:
+  DynatraceAwsSecurityHubEventForwarderLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: dynatrace-aws-security-hub-event-forwarder-lambda-role
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSLambdaExecute
+      Path: /
+      Policies:
+        - PolicyName: "dynatrace-aws-security-hub-event-forwarder-read-dynatrace-secret-token"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "secretsmanager:GetSecretValue"
+                Resource: !Ref AwsSecretArn
+                Sid: "VisualEditor0"
+
+  DynatraceAwsSecurityHubEventForwarderLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dynatrace-aws-security-hub-event-forwarder-lambda
+      Description: Dynatrace AWS security hub event forwarder lambda function.
+      TracingConfig:
+        Mode: "PassThrough"
+      Runtime: python3.12
+      Code:
+        ZipFile: |
+          import http.client
+          import json
+          import boto3
+          import copy
+          import os
+          import uuid
+
+          AWS_SECRET_ARN = os.environ["AWS_SECRET_ARN"]
+          AWS_SECRET_KEY_NAME = os.environ["AWS_SECRET_KEY_NAME"]
+
+          DYNATRACE_DOMAIN = os.environ["DYNATRACE_DOMAIN"]
+          DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH = os.environ["DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH"]
+
+          def lambda_handler(event, context):
+              try:
+                  # get token from secret manager
+                  token = get_token_secret()
+                  detail_type = event.get("detail-type")
+
+                  if detail_type == "Security Hub Findings - Imported":
+                      process_finding(event, token)
+                  else:
+                      raise Exception(f'Unsupported detail-type: "{str(detail_type)}"')
+
+                  return {
+                      "statusCode": 200,
+                      "body": json.dumps("Executed OpenPipeline security event export")
+                  }
+              except Exception as e:
+                  print(f'Error executing OpenPipeline security event export: {str(e)}')
+
+                  return {
+                      'statusCode': 500,
+                      'body': 'Error executing OpenPipeline security event export'
+                  }
+
+          def get_token_secret():
+              # Create a Secrets Manager client
+              session = boto3.session.Session()
+              client = session.client(
+                  service_name="secretsmanager"
+              )
+
+              get_secret_value_response = client.get_secret_value(
+                  SecretId=AWS_SECRET_ARN
+              )
+
+              # json string containing the secret
+              secret_json = get_secret_value_response["SecretString"]
+              secret_dict = json.loads(secret_json)
+
+              return secret_dict[AWS_SECRET_KEY_NAME]
+
+          def process_finding(event, token):
+              process_entries = []
+              for vulnerablePackage in event.get("detail").get("findings")[0].get("Vulnerabilities")[0].get("VulnerablePackages"):
+                  processed_entry = copy.deepcopy(event)
+                  processed_entry["detail"]["findings"][0]["Vulnerabilities"][0]["VulnerablePackages"] = [vulnerablePackage]
+
+                  # add random uuid
+                  random_event_id = uuid.uuid4()
+                  processed_entry["uuid"] = str(random_event_id)
+
+                  process_entries.append(processed_entry)
+
+              json_string = json.dumps(process_entries, default=str)
+              send_data_to_pipeline(json_string, token)
+
+          def send_data_to_pipeline(data, token):
+              conn = http.client.HTTPSConnection(DYNATRACE_DOMAIN)
+
+              headers = {
+                  "Authorization": "Api-Token " + token,
+                  "Content-Type": "application/json",
+              }
+
+              conn.request("POST", DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH, body=data, headers=headers)
+              response = conn.getresponse()
+
+              if response.status > 299:
+                  print(f"Error sending sending data to OpenPipeline, response status is: {str(response.status)}")
+      Handler: "index.lambda_handler"
+      MemorySize: 128
+      Timeout: 600
+      Role: !GetAtt DynatraceAwsSecurityHubEventForwarderLambdaRole.Arn
+      Environment:
+        Variables:
+          AWS_SECRET_ARN: !Ref AwsSecretArn
+          AWS_SECRET_KEY_NAME: !Ref AwsSecretKeyName
+          DYNATRACE_DOMAIN: !Ref DynatraceDomain
+          DYNATRACE_OPENPIPELINE_SECURITY_ENDPOINT_PATH: !Ref DynatraceOpenPipelineEndpointPath
+
+  DynatraceAwsSecurityHubFindingEventRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: "Forwards the security hub findings to the aws-security-hub-lambda function, which sends it to OpenPipeline"
+      EventPattern:
+        detail-type:
+          - "Security Hub Findings - Imported"
+        detail:
+          findings:
+            Types: !Split [",", !Ref FindingTypes]
+        source:
+          - "aws.securityhub"
+      EventBusName: "default"
+      Targets:
+        - Arn: !GetAtt DynatraceAwsSecurityHubEventForwarderLambdaFunction.Arn
+          Id: "TargetFunction"
+
+  DynatraceAwsSecurityHubEventForwarderLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt DynatraceAwsSecurityHubEventForwarderLambdaFunction.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DynatraceAwsSecurityHubFindingEventRule.Arn


### PR DESCRIPTION
This PR adds a Cloud Formation template for the AWS Security Hub event forwarder. Vulnerability finding events from AWS Security Hub are currently supported.