### PR TITLE
Update readme for deprecated artifacts

### DIFF
--- a/aws/aws-ecr-event-forwarder-enhanced/README.md
+++ b/aws/aws-ecr-event-forwarder-enhanced/README.md
@@ -1,4 +1,7 @@
 # AWS Event Forwarder Lambda - Enhanced scanning
+Note: Since the introduction of the Grail security table, up-to-date artifacts are now delivered directly in-product through new integrations.
+As a result, the artifacts in this repository are no longer maintained and will become outdated.
+For further details, see the [Grail security table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
 
 This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings and scan events for [enhanced scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html) to the Dynatrace OpenPipeline security event ingest endpoint.
 

--- a/aws/aws-ecr-event-forwarder/README.md
+++ b/aws/aws-ecr-event-forwarder/README.md
@@ -1,4 +1,7 @@
 # AWS Event Forwarder Lambda - Basic scanning
+Note: Since the introduction of the Grail security table, up-to-date artifacts are now delivered directly in-product through new integrations. 
+As a result, the artifacts in this repository are no longer maintained and will become outdated. 
+For further details, see the [Grail security table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
 
 This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up necessary resources in AWS to forward AWS Elastic Container Registry (ECR) container vulnerability findings and scan events for [basic scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-basic.html) to the Dynatrace OpenPipeline security event ingest endpoint.
 

--- a/aws/aws-security-hub-event-forwarder/README.md
+++ b/aws/aws-security-hub-event-forwarder/README.md
@@ -1,4 +1,7 @@
 # AWS Security Hub event forwarder
+Note: Since the introduction of the Grail security table, up-to-date artifacts are now delivered directly in-product through new integrations.
+As a result, the artifacts in this repository are no longer maintained and will become outdated.
+For further details, see the [Grail security table migration guide](https://docs.dynatrace.com/docs/secure/threat-observability/migration).
 
 This folder contains an [AWS Cloud Formation](https://aws.amazon.com/cloudformation/) template, which sets up the necessary resources in AWS to forward AWS Security Hub to the Dynatrace OpenPipeline security event ingest endpoint.
 


### PR DESCRIPTION
We are deprecating the CloudFormation templates, that is why we need to update the readme file accordingly.