### PR TITLE
event-hub-deployment: create dynatrace consumer group for logs & events event hubs

### DIFF
--- a/azure/event-hub-deployment/armTemplate.jsonc
+++ b/azure/event-hub-deployment/armTemplate.jsonc
@@ -162,7 +162,13 @@
             "evhnsSuffix": {"type": "string"}
           },
           "variables": {
-            "evhnsName": "[if(empty(parameters('evhnsSuffix')), format('evhns-dt-{0}-{1}', parameters('dtTenantId'), parameters('location')), format('evhns-dt-{0}-{1}-{2}', parameters('dtTenantId'), parameters('location'), parameters('evhnsSuffix')))]"
+            "evhnsName": "[if(empty(parameters('evhnsSuffix')), format('evhns-dt-{0}-{1}', parameters('dtTenantId'), parameters('location')), format('evhns-dt-{0}-{1}-{2}', parameters('dtTenantId'), parameters('location'), parameters('evhnsSuffix')))]",
+            "isBasicSku": "[equals(toLower(parameters('skuName')), 'basic')]",
+            // Basic SKU does not support custom consumer groups (only $Default is allowed)
+            "isNotBasicSku": "[not(variables('isBasicSku'))]",
+            // Basic SKU caps message retention at 1 day; coerce to avoid deployment failure
+            "effectiveLogsRetentionInDays": "[if(variables('isBasicSku'), 1, parameters('evhLogsRetentionInDays'))]",
+            "effectiveEventsRetentionInDays": "[if(variables('isBasicSku'), 1, parameters('evhEventsRetentionInDays'))]"
           },
           "resources": [
             {
@@ -202,10 +208,19 @@
                 "[resourceId('Microsoft.EventHub/namespaces', variables('evhnsName'))]"
               ],
               "properties": {
-                "messageRetentionInDays": "[parameters('evhLogsRetentionInDays')]",
+                "messageRetentionInDays": "[variables('effectiveLogsRetentionInDays')]",
                 "partitionCount": "[parameters('evhLogsPartitionCount')]"
               }
               // Note: Tags cannot be applied to Event Hubs.
+            },
+            {
+              "condition": "[variables('isNotBasicSku')]",
+              "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
+              "apiVersion": "2021-11-01",
+              "name": "[format('{0}/dt-logs-evh/dynatrace', variables('evhnsName'))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('evhnsName'), 'dt-logs-evh')]"
+              ]
             },
             {
               "type": "Microsoft.EventHub/namespaces/eventhubs",
@@ -215,10 +230,19 @@
                 "[resourceId('Microsoft.EventHub/namespaces', variables('evhnsName'))]"
               ],
               "properties": {
-                "messageRetentionInDays": "[parameters('evhEventsRetentionInDays')]",
+                "messageRetentionInDays": "[variables('effectiveEventsRetentionInDays')]",
                 "partitionCount": "[parameters('evhEventsPartitionCount')]"
               }
               // Note: Tags cannot be applied to Event Hubs.
+            },
+            {
+              "condition": "[variables('isNotBasicSku')]",
+              "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
+              "apiVersion": "2021-11-01",
+              "name": "[format('{0}/dt-events-evh/dynatrace', variables('evhnsName'))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('evhnsName'), 'dt-events-evh')]"
+              ]
             }
           ]
         },

--- a/azure/event-hub-deployment/createUiDefinition.json
+++ b/azure/event-hub-deployment/createUiDefinition.json
@@ -253,7 +253,8 @@
                 "toolTip": "Number of days to retain log messages (1-7)",
                 "constraints": {
                   "required": true
-                }
+                },
+                "visible": "[not(equals(steps('eventHubConfig').eventHubNamespace.skuName, 'Basic'))]"
               }
             ]
           },
@@ -294,7 +295,8 @@
                 "toolTip": "Number of days to retain event messages (1-7)",
                 "constraints": {
                   "required": true
-                }
+                },
+                "visible": "[not(equals(steps('eventHubConfig').eventHubNamespace.skuName, 'Basic'))]"
               }
             ]
           }
@@ -334,9 +336,9 @@
       "skuCapacity": "[if(equals(steps('eventHubConfig').configurationSize, 'Custom'), steps('eventHubConfig').eventHubNamespace.skuCapacity, 1)]",
       "maximumThroughputUnits": "[coalesce(first(map(filter(parse('[{\"config\":\"DevTest\",\"maxTU\":1},{\"config\":\"Small\",\"maxTU\":4},{\"config\":\"Medium\",\"maxTU\":16},{\"config\":\"Large\",\"maxTU\":32}]'), (item) => equals(item.config, steps('eventHubConfig').configurationSize)), (item) => item.maxTU)), steps('eventHubConfig').eventHubNamespace.maximumThroughputUnits)]",
       "evhLogsPartitionCount": "[coalesce(first(map(filter(parse('[{\"config\":\"DevTest\",\"partitions\":1},{\"config\":\"Small\",\"partitions\":4},{\"config\":\"Medium\",\"partitions\":16},{\"config\":\"Large\",\"partitions\":32}]'), (item) => equals(item.config, steps('eventHubConfig').configurationSize)), (item) => item.partitions)), int(steps('eventHubConfig').logsEventHub.partitionCount))]",
-      "evhLogsRetentionInDays": "[if(equals(steps('eventHubConfig').configurationSize, 'Custom'), steps('eventHubConfig').logsEventHub.retentionInDays, 1)]",
+      "evhLogsRetentionInDays": "[if(and(equals(steps('eventHubConfig').configurationSize, 'Custom'), not(equals(steps('eventHubConfig').eventHubNamespace.skuName, 'Basic'))), steps('eventHubConfig').logsEventHub.retentionInDays, 1)]",
       "evhEventsPartitionCount": "[coalesce(first(map(filter(parse('[{\"config\":\"DevTest\",\"partitions\":1},{\"config\":\"Small\",\"partitions\":1},{\"config\":\"Medium\",\"partitions\":1},{\"config\":\"Large\",\"partitions\":2}]'), (item) => equals(item.config, steps('eventHubConfig').configurationSize)), (item) => item.partitions)), int(steps('eventHubConfig').eventsEventHub.partitionCount))]",
-      "evhEventsRetentionInDays": "[if(equals(steps('eventHubConfig').configurationSize, 'Custom'), steps('eventHubConfig').eventsEventHub.retentionInDays, 1)]",
+      "evhEventsRetentionInDays": "[if(and(equals(steps('eventHubConfig').configurationSize, 'Custom'), not(equals(steps('eventHubConfig').eventHubNamespace.skuName, 'Basic'))), steps('eventHubConfig').eventsEventHub.retentionInDays, 1)]",
       "tags": "[steps('tags').customTags]"
     },
     "resourceTypes": [


### PR DESCRIPTION
### event-hub-deployment

Updated ARM template:
- To create dynatrace consumer group for logs & events event hubs if SKU is not "Basic".
- Ignore evhLogsRetentionInDays and evhEventsRetentionInDays parameter is SKU is "Basic" and use 1 as default.

Updated Azure UI Definition:
- To not show "Message Retention (days)" field for logs and events if "Basic" SKU is selected and use 1 as default.